### PR TITLE
(feat): Add AI moderation & notifications UI

### DIFF
--- a/src/pages/Admin/LiveOps/EpisodeRequestsPage.tsx
+++ b/src/pages/Admin/LiveOps/EpisodeRequestsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Mic, Search, CheckCircle, XCircle, Clock, User, Play, RefreshCw, X, FileAudio } from 'lucide-react';
+import { Mic, Search, CheckCircle, XCircle, Clock, User, Play, RefreshCw, X, FileAudio, ShieldAlert, ShieldCheck, Shield, Loader2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { liveSessionApiService, type PodcastEpisodeRequestResult, type PodcastResult } from '../../../services/liveSessionApiService';
+import { liveSessionApiService, type PodcastEpisodeRequestResult, type PodcastResult, type ModerationCheckResult } from '../../../services/liveSessionApiService';
 import { showSuccess, showError } from '../../../components/common/toastUtils';
 import '../LiveOps/LiveOps.css';
 
@@ -14,6 +14,8 @@ export function EpisodeRequestsPage() {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedRequest, setSelectedRequest] = useState<PodcastEpisodeRequestResult | null>(null);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [moderationResult, setModerationResult] = useState<ModerationCheckResult | null>(null);
+  const [isCheckingToxicity, setIsCheckingToxicity] = useState(false);
 
   // Optional: Cache for podcast info
   const [podcastsCache, setPodcastsCache] = useState<Record<string, PodcastResult>>({});
@@ -49,6 +51,7 @@ export function EpisodeRequestsPage() {
 
   const openDetail = (request: PodcastEpisodeRequestResult) => {
     setSelectedRequest(request);
+    setModerationResult(null);
     if (request.podcastId) {
       loadPodcastInfo(request.podcastId);
     }
@@ -84,6 +87,37 @@ export function EpisodeRequestsPage() {
       showError('Lỗi', err?.response?.data?.message || 'Không thể từ chối yêu cầu');
     } finally {
       setActionLoading(null);
+    }
+  };
+
+  const handleQuickReject = async (id: string, reason: string) => {
+    setActionLoading(id);
+    try {
+      const updated = await liveSessionApiService.reviewPodcastEpisodeRequest(id, {
+        isApproved: false,
+        rejectReason: reason,
+      });
+      setRequests(prev => prev.map(r => r.id === id ? updated : r));
+      if (selectedRequest?.id === id) setSelectedRequest(updated);
+      showSuccess('Thành công', 'Yêu cầu tập mới đã bị từ chối');
+    } catch (err: any) {
+      showError('Lỗi', err?.response?.data?.message || 'Không thể từ chối yêu cầu');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const handleCheckToxicity = async () => {
+    if (!selectedRequest) return;
+    setIsCheckingToxicity(true);
+    setModerationResult(null);
+    try {
+      const result = await liveSessionApiService.checkPodcastEpisodeToxicity(selectedRequest.id);
+      setModerationResult(result);
+    } catch (err: any) {
+      showError('Lỗi kiểm duyệt', err?.response?.data?.message || 'Không thể kiểm duyệt bằng AI');
+    } finally {
+      setIsCheckingToxicity(false);
     }
   };
 
@@ -329,6 +363,98 @@ export function EpisodeRequestsPage() {
                   </div>
                 )}
               </div>
+
+              {selectedRequest.status === 'Pending' && selectedRequest.audioUrl && (
+                <div style={{ marginTop: 24, padding: 16, backgroundColor: '#f8fafc', borderRadius: 8, border: '1px solid #e2e8f0' }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: moderationResult ? 16 : 0 }}>
+                    <div>
+                      <h4 style={{ margin: 0, fontSize: 14, fontWeight: 600, display: 'flex', alignItems: 'center', gap: 6 }}>
+                        <Shield size={16} /> Kiểm duyệt nội dung tự động (AI)
+                      </h4>
+                      <p style={{ margin: '4px 0 0 0', fontSize: 12, color: '#64748b' }}>
+                        Phân tích âm thanh và phát hiện các từ ngữ vi phạm, thô tục.
+                      </p>
+                    </div>
+                    <button 
+                      className="ops-btn ops-btn--primary" 
+                      onClick={handleCheckToxicity}
+                      disabled={isCheckingToxicity}
+                      style={{ height: 32, padding: '0 12px', fontSize: 12 }}
+                    >
+                      {isCheckingToxicity ? <><Loader2 size={14} className="pe-spin"/> Đang xử lý...</> : <><ShieldAlert size={14}/> Kiểm duyệt ngay</>}
+                    </button>
+                  </div>
+
+                  {moderationResult && (
+                    <div style={{ 
+                      marginTop: 16, 
+                      padding: 12, 
+                      borderRadius: 6, 
+                      backgroundColor: moderationResult.action === 'REJECT' ? '#fef2f2' : moderationResult.action === 'PENDING_REVIEW' ? '#fffbeb' : '#f0fdf4',
+                      border: `1px solid ${moderationResult.action === 'REJECT' ? '#fecaca' : moderationResult.action === 'PENDING_REVIEW' ? '#fef3c7' : '#bbf7d0'}` 
+                    }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8, color: moderationResult.action === 'REJECT' ? '#b91c1c' : moderationResult.action === 'PENDING_REVIEW' ? '#d97706' : '#15803d' }}>
+                        {moderationResult.action === 'SAFE' ? <ShieldCheck size={18} /> : <ShieldAlert size={18} />}
+                        <strong style={{ fontSize: 14 }}>
+                          {moderationResult.action === 'REJECT' ? 'Phát hiện nội dung vi phạm nghiêm trọng' : 
+                           moderationResult.action === 'PENDING_REVIEW' ? 'Cần xem xét kỹ nội dung' : 
+                           'Nội dung an toàn'}
+                        </strong>
+                      </div>
+                      
+                      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 8, marginBottom: 12 }}>
+                        <div style={{ padding: 8, backgroundColor: '#fff', borderRadius: 4, border: '1px solid #e2e8f0', textAlign: 'center' }}>
+                          <div style={{ fontSize: 11, color: '#64748b', textTransform: 'uppercase' }}>Toxicity</div>
+                          <div style={{ fontSize: 16, fontWeight: 700, color: moderationResult.toxicityScore >= 0.5 ? '#ef4444' : '#334155' }}>
+                            {Math.round(moderationResult.toxicityScore * 100)}%
+                          </div>
+                        </div>
+                        <div style={{ padding: 8, backgroundColor: '#fff', borderRadius: 4, border: '1px solid #e2e8f0', textAlign: 'center' }}>
+                          <div style={{ fontSize: 11, color: '#64748b', textTransform: 'uppercase' }}>Profanity</div>
+                          <div style={{ fontSize: 16, fontWeight: 700, color: moderationResult.profanityScore >= 0.5 ? '#ef4444' : '#334155' }}>
+                            {Math.round(moderationResult.profanityScore * 100)}%
+                          </div>
+                        </div>
+                        <div style={{ padding: 8, backgroundColor: '#fff', borderRadius: 4, border: '1px solid #e2e8f0', textAlign: 'center' }}>
+                          <div style={{ fontSize: 11, color: '#64748b', textTransform: 'uppercase' }}>Insult</div>
+                          <div style={{ fontSize: 16, fontWeight: 700, color: moderationResult.insultScore >= 0.5 ? '#ef4444' : '#334155' }}>
+                            {Math.round(moderationResult.insultScore * 100)}%
+                          </div>
+                        </div>
+                      </div>
+
+                      {moderationResult.triggeredWords && moderationResult.triggeredWords.length > 0 && (
+                        <div style={{ fontSize: 13, marginBottom: 12 }}>
+                          <strong>Từ ngữ vi phạm: </strong>
+                          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginTop: 4 }}>
+                            {moderationResult.triggeredWords.map((w, i) => (
+                              <span key={i} style={{ padding: '2px 6px', backgroundColor: 'rgba(239, 68, 68, 0.1)', color: '#ef4444', borderRadius: 4, fontWeight: 500 }}>{w}</span>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      <div style={{ fontSize: 13, maxHeight: 150, overflowY: 'auto', backgroundColor: 'rgba(255,255,255,0.6)', padding: 8, borderRadius: 4, border: '1px solid rgba(0,0,0,0.05)' }}>
+                        <strong>Bản dịch (Transcript):</strong>
+                        <p style={{ margin: '4px 0 0 0', whiteSpace: 'pre-wrap', color: '#475569' }}>
+                          {moderationResult.transcript}
+                        </p>
+                      </div>
+
+                      {moderationResult.action === 'REJECT' && (
+                        <div style={{ marginTop: 12, display: 'flex', justifyContent: 'flex-end' }}>
+                           <button className="pe-confirm-delete" style={{ padding: '6px 12px', fontSize: 12 }} onClick={() => {
+                             setSelectedRequest(null);
+                             handleQuickReject(selectedRequest.id, "Vi phạm tiêu chuẩn cộng đồng (Phát hiện bởi AI)");
+                           }}>
+                             <XCircle size={14} /> Từ chối tự động
+                           </button>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
 
             <div className="ops-modal-foot">

--- a/src/pages/Livestream/LiveRoomPage.css
+++ b/src/pages/Livestream/LiveRoomPage.css
@@ -1342,4 +1342,177 @@
     0%, 100% { opacity: 1; }
     50% { opacity: 0.3; }
 }. l r - r e q u e s t - l i m i t s - b a d g e   {   b a c k g r o u n d - c o l o r :   r g b a ( 1 6 7 ,   1 3 9 ,   2 5 0 ,   0 . 1 5 ) ;   c o l o r :   # a 7 8 b f a ;   p a d d i n g :   4 p x   8 p x ;   b o r d e r - r a d i u s :   1 2 p x ;   f o n t - s i z e :   0 . 8 r e m ;   f o n t - w e i g h t :   6 0 0 ;   m a r g i n - l e f t :   a u t o ;   m a r g i n - r i g h t :   1 2 p x ;   b o r d e r :   1 p x   s o l i d   r g b a ( 1 6 7 ,   1 3 9 ,   2 5 0 ,   0 . 3 ) ;   }  
- 
+  
+ /* -- Notifications Toast & Tab -- */
+.lr-notification-toast {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%) translateY(-150%);
+  background: rgba(30, 30, 35, 0.95);
+  backdrop-filter: blur(16px);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 12px;
+  padding: 16px 20px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  z-index: 1000;
+  transition: transform 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275), opacity 0.4s ease;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  width: max-content;
+  max-width: 90%;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.lr-notification-toast.show {
+  transform: translateX(-50%) translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.lr-toast-icon {
+  background: linear-gradient(135deg, var(--sys-primary), var(--sys-primary-hover, #1ed760));
+  color: #000;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.lr-toast-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.lr-toast-content h4 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.lr-toast-content p {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.7);
+  max-width: 300px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.lr-toast-close {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: all 0.2s ease;
+}
+
+.lr-toast-close:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.lr-notif-badge {
+  background: #e91e63;
+  color: #fff;
+  font-size: 10px;
+  font-weight: bold;
+  padding: 2px 6px;
+  border-radius: 10px;
+  margin-left: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.lr-notifications-tab {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 16px;
+}
+
+.lr-notif-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+  height: 100%;
+}
+
+.lr-notif-list::-webkit-scrollbar {
+  width: 4px;
+}
+
+.lr-notif-list::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+}
+
+.lr-notif-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 16px;
+  border-radius: 12px;
+  transition: background 0.2s ease;
+}
+
+.lr-notif-item:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.lr-notif-item-icon {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--sys-primary);
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.lr-notif-item-content {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.lr-notif-item-content h4 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.lr-notif-item-content p {
+  margin: 0;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.7);
+  line-height: 1.4;
+}
+
+.lr-notif-time {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.4);
+  align-self: flex-end;
+}

--- a/src/pages/Livestream/LiveRoomPage.tsx
+++ b/src/pages/Livestream/LiveRoomPage.tsx
@@ -30,6 +30,8 @@ import {
   MoreVertical,
   Mic2,
   MicOff,
+  Bell,
+  BellOff
 } from "lucide-react";
 import { showToast } from "../../utils/toast";
 import { liveSessionApiService } from "../../services/liveSessionApiService";
@@ -37,8 +39,13 @@ import type { SongRequestResult } from "../../services/liveSessionApiService";
 import { useLiveSession } from "../../context/LiveSessionContext";
 import { usePlayer } from "../../context/PlayerContext";
 import { liveHubService } from "../../services/liveHubService";
+import notificationHubService, {
+  type RealtimeNotification,
+  type BroadcastNotification,
+} from "../../services/notificationHubService";
 import AuthPromptModal from "../../components/common/AuthPromptModal";
 import UpgradeModal from "../../components/common/UpgradeModal";
+import NotificationButton from "../../components/layout/NotificationButton";
 import "./LiveRoomPage.css";
 
 // ─── Types (local UI only) ────────────────────────────────────────────────────
@@ -65,6 +72,13 @@ interface SystemMusicItem {
   album: string | null;
   artUrl?: string | null;
   artworkUrl?: string | null;
+}
+
+interface RoomNotification {
+  id: string;
+  title: string;
+  message: string;
+  time: string;
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -187,6 +201,9 @@ export function LiveRoomPage() {
   const [activeDotMenu, setActiveDotMenu] = useState<string | null>(null);
   const [activeChatTab, setActiveChatTab] = useState<"chat" | "history" | "lyrics">("chat");
   const [showAuthPopup, setShowAuthPopup] = useState(false);
+  
+  // ── Notifications State (Toast Only) ──────────────────────────────────────
+  const [activeToast, setActiveToast] = useState<RoomNotification | null>(null);
   const [authPopupMode, setAuthPopupMode] = useState<AuthPopupMode>("guestLimit");
   const [manualSyncBaseMs, setManualSyncBaseMs] = useState<number | null>(null);
   const [manualSyncClockMs, setManualSyncClockMs] = useState<number | null>(null);
@@ -429,6 +446,50 @@ export function LiveRoomPage() {
     return () => window.removeEventListener("guestLimitReached", handleGuestLimit);
   }, []);
 
+  // ── Global Notifications (NotificationHub) ────────────────────────────────
+  useEffect(() => {
+    const token = localStorage.getItem("accessToken");
+    if (!token) return;
+
+    let cleanupPersonal: (() => void) | null = null;
+    let cleanupBroadcast: (() => void) | null = null;
+    let toastTimeout: ReturnType<typeof setTimeout> | null = null;
+
+    const showToastNotif = (title: string, message: string) => {
+      const msgStr = typeof message === "string" ? message : JSON.stringify(message);
+      const newNotif: RoomNotification = {
+        id: Math.random().toString(36).substring(2, 9),
+        title,
+        message: msgStr,
+        time: new Date().toISOString()
+      };
+      
+      // Show toast
+      setActiveToast(newNotif);
+      if (toastTimeout) clearTimeout(toastTimeout);
+      toastTimeout = setTimeout(() => {
+        setActiveToast(null);
+      }, 5000);
+    };
+
+    notificationHubService.start(token).then(() => {
+      cleanupPersonal = notificationHubService.onReceiveNotification((n: RealtimeNotification) => {
+        showToastNotif(n.title || "Thông báo mới", n.message);
+      });
+      cleanupBroadcast = notificationHubService.onReceiveBroadcastNotification((n: BroadcastNotification) => {
+        showToastNotif(n.title || "Hệ thống", n.message);
+      });
+    }).catch(err => {
+      console.warn("[LiveRoomPage] NotificationHub start failed:", err);
+    });
+
+    return () => {
+      cleanupPersonal?.();
+      cleanupBroadcast?.();
+      if (toastTimeout) clearTimeout(toastTimeout);
+    };
+  }, []);
+
   // ── Song request ──────────────────────────────────────────────────────────
   const loadRequestableSongs = useCallback(async () => {
     if (!session?.stationId) return;
@@ -573,6 +634,7 @@ export function LiveRoomPage() {
           </div>
         </div>
         <div className="lr-topbar-right">
+          <NotificationButton />
           <span className="lr-live-indicator">
             {session?.status?.toLowerCase() === "live" ? "LIVE" : "OFFLINE"}
           </span>
@@ -668,6 +730,24 @@ export function LiveRoomPage() {
                   )}
                 </div>
               </div>
+            )}
+          </div>
+
+          {/* Active Toast Overlay */}
+          <div className={`lr-notification-toast ${activeToast ? "show" : ""}`}>
+            {activeToast && (
+              <>
+                <div className="lr-toast-icon">
+                  <Bell size={20} />
+                </div>
+                <div className="lr-toast-content">
+                  <h4>{activeToast.title}</h4>
+                  <p>{activeToast.message}</p>
+                </div>
+                <button className="lr-toast-close" onClick={() => setActiveToast(null)}>
+                  <X size={16} />
+                </button>
+              </>
             )}
           </div>
         </div>

--- a/src/services/liveSessionApiService.ts
+++ b/src/services/liveSessionApiService.ts
@@ -502,6 +502,15 @@ export interface PodcastEpisodeRequestResult {
   requestedAt: string;
 }
 
+export interface ModerationCheckResult {
+  toxicityScore: number;
+  insultScore: number;
+  profanityScore: number;
+  action: string;
+  triggeredWords: string[];
+  transcript: string;
+}
+
 export interface PagedResult<T> {
   items: T[];
   totalCount: number;
@@ -884,6 +893,13 @@ class LiveSessionApiService {
     const res = await api.post<ApiResponse<PodcastEpisodeRequestResult>>(
       `/podcast-episode-requests/${id}/review`,
       data,
+    );
+    return res.data.data;
+  }
+
+  async checkPodcastEpisodeToxicity(id: string): Promise<ModerationCheckResult> {
+    const res = await api.post<ApiResponse<ModerationCheckResult>>(
+      `/podcast-episode-requests/${id}/check-toxicity`
     );
     return res.data.data;
   }


### PR DESCRIPTION
Add AI moderation for podcast episode requests and realtime notifications for the live room. EpisodeRequestsPage: import new icons, add ModerationCheckResult state, implement checkPodcastEpisodeToxicity call, quick-reject action, and render moderation panel showing scores, triggered words, transcript and an auto-reject button. liveSessionApiService: add ModerationCheckResult type and checkPodcastEpisodeToxicity API method. LiveRoomPage: integrate notificationHubService, show transient toast notifications, add NotificationButton to topbar and corresponding RoomNotification state. LiveRoomPage.css: add styles for notification toast, list and related UI.